### PR TITLE
[Add] cao-bot online & offline API 생성

### DIFF
--- a/src/main/java/com/caobot/application/CaoBotConnection.java
+++ b/src/main/java/com/caobot/application/CaoBotConnection.java
@@ -3,10 +3,12 @@ package com.caobot.application;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Activity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.security.auth.login.LoginException;
+import java.util.Scanner;
 
 @Service
 public class CaoBotConnection {
@@ -24,20 +26,17 @@ public class CaoBotConnection {
             jda = JDABuilder.createDefault(AccountType.BOT.name())
                     .setToken(bot_token)
                     .addEventListeners(new MessageService())
-//                    .setActivity(Activity.watching("I am Cao-Bot!"))
+                    .setActivity(Activity.watching("cao-bot 운영 중!"))
                     .build();
 
-            jda.awaitReady();
             System.out.println("Finished Building JDA!");
         } catch (LoginException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
             e.printStackTrace();
         }
     }
 
-//    public static void stop() {
-//        jda.shutdown();
-//        System.out.println("Finished shutdown JDA!");
-//    }
+    public static void stop() {
+        jda.shutdown();
+        System.out.println("Finished Stopping JDA!");
+    }
 }

--- a/src/main/java/com/caobot/application/CaoBotConnection.java
+++ b/src/main/java/com/caobot/application/CaoBotConnection.java
@@ -1,0 +1,43 @@
+package com.caobot.application;
+
+import net.dv8tion.jda.api.AccountType;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.security.auth.login.LoginException;
+
+@Service
+public class CaoBotConnection {
+    private static JDA jda;
+
+    private static String bot_token;
+
+    @Value("${user.token}")
+    private void setBotToken(String value) {
+        this.bot_token = value;
+    }
+
+    public static void start() {
+        try {
+            jda = JDABuilder.createDefault(AccountType.BOT.name())
+                    .setToken(bot_token)
+                    .addEventListeners(new MessageService())
+//                    .setActivity(Activity.watching("I am Cao-Bot!"))
+                    .build();
+
+            jda.awaitReady();
+            System.out.println("Finished Building JDA!");
+        } catch (LoginException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+//    public static void stop() {
+//        jda.shutdown();
+//        System.out.println("Finished shutdown JDA!");
+//    }
+}

--- a/src/main/java/com/caobot/application/MessageService.java
+++ b/src/main/java/com/caobot/application/MessageService.java
@@ -1,36 +1,12 @@
 package com.caobot.application;
 
-import net.dv8tion.jda.api.AccountType;
-import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.events.application.ApplicationCommandUpdateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import javax.annotation.Nonnull;
-import javax.security.auth.login.LoginException;
 
 @Service
 public class MessageService extends ListenerAdapter {
-    private static String bot_token;
-
-    @Value("${user.token}")
-    private void setBotToken(String value) {
-        this.bot_token = value;
-    }
-
-    public static void CaoBotLoad() throws LoginException, InterruptedException {
-        JDA jda = JDABuilder.createDefault(AccountType.BOT.name())
-                .setToken(bot_token)
-                .addEventListeners(new MessageService())
-                .build();
-
-        jda.awaitReady();
-        System.out.println("Finished Building JDA!");
-    }
-
     @Override
     public void onMessageReceived(MessageReceivedEvent event)
     {

--- a/src/main/java/com/caobot/controller/CaoBotController.java
+++ b/src/main/java/com/caobot/controller/CaoBotController.java
@@ -7,12 +7,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CaoBotController {
     @GetMapping("/start")
-    public void startCaoBot(){
+    public void startCaoBot() {
         CaoBotConnection.start();
     }
 
-//    @GetMapping("/stop")
-//    public void stopCaoBot(){
-//        BotConnection.stop();
-//    }
+    @GetMapping("/stop")
+    public void stopCaoBot(){
+        CaoBotConnection.stop();
+    }
 }

--- a/src/main/java/com/caobot/controller/CaoBotController.java
+++ b/src/main/java/com/caobot/controller/CaoBotController.java
@@ -1,0 +1,18 @@
+package com.caobot.controller;
+
+import com.caobot.application.CaoBotConnection;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CaoBotController {
+    @GetMapping("/start")
+    public void startCaoBot(){
+        CaoBotConnection.start();
+    }
+
+//    @GetMapping("/stop")
+//    public void stopCaoBot(){
+//        BotConnection.stop();
+//    }
+}

--- a/src/main/java/com/caobot/controller/MessageController.java
+++ b/src/main/java/com/caobot/controller/MessageController.java
@@ -6,11 +6,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.security.auth.login.LoginException;
 
-@RestController
 public class MessageController {
 
-    @GetMapping("/")
-    public void loadCaoBot() throws LoginException, InterruptedException {
-        MessageService.CaoBotLoad();
-    }
+//    @GetMapping("/message")
+//    public void loadCaoBot() throws LoginException, InterruptedException {
+//        MessageService.onMessageReceived();
+//    }
 }


### PR DESCRIPTION
1. `CaoBotController` 을 통해 bot online 및 offline url 분기 처리
2. `CaoBotConnection` 의 `start` 메서드
      - token 등록, Message 기능 등록 (Message 기능은 추후 위치 조정 필요)
3. `CaoBotConnection` 의 `stop` 메서드 (未)
4. `MessageService` 내부에 bot 생성 기능 삭제